### PR TITLE
Improve next-auth route security

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { LoadingModal } from "@/components/common";
 import { LearnMoreModal } from "@/components";
 import { useRouter } from "next/navigation";
 import { LOGIN } from "@/const/routes";
+import useRedirectIfAuthenticated from "@/hook/useRedirectIfAuthenticated";
 
 type ListType = {
   id: string;
@@ -37,6 +38,7 @@ const ONE = 1;
 
 export default function BookSearchList() {
   const router = useRouter();
+  useRedirectIfAuthenticated();
   const [searchValue, setSearchValue] = React.useState("");
   const [books, setBooks] = React.useState<DataType | null>(null);
   const [selectedBook, setSelectedBook] = React.useState<ListType | null>(null);

--- a/src/const/routes.ts
+++ b/src/const/routes.ts
@@ -26,7 +26,7 @@ export const RETURN_CREATE = "/admin/return/create";
 export const LOGIN = "/login";
 export const REGISTER = "/register";
 
-export const PUBLIC_ROUTE = [LOGIN];
+export const PUBLIC_ROUTE = [USER_DASHBOARD, LOGIN];
 
 export const LOADING_DISABLE = [
   TEACHER_LIST,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,19 +16,31 @@ export default withAuth(
 
     if (!userToken) return;
     const isPublicRoutes = PUBLIC_ROUTE.includes(pathName);
+    const isAdminRoutes = pathName.startsWith("/admin");
     const isAdmin = userToken?.user?.role === ADMIN;
 
     if (isPublicRoutes && isAdmin) {
       return NextResponse.redirect(new URL(ADMIN_DASHBOARD, req.url));
     }
+
+    if (isAdminRoutes && !isAdmin) {
+      return NextResponse.redirect(new URL(LOGIN, req.url));
+    }
   },
   {
     callbacks: {
       authorized: ({ req, token }) => {
-        if (req.nextUrl.pathname === USER_DASHBOARD) {
-          return true;
+        const pathName = req.nextUrl.pathname;
+
+        if (PUBLIC_ROUTE.includes(pathName)) return true;
+
+        if (!token) return false;
+
+        if (pathName.startsWith("/admin")) {
+          return token.user?.role === ADMIN;
         }
-        return !!token;
+
+        return true;
       },
     },
     pages: {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -7,6 +7,7 @@ declare module "next-auth" {
       name?: string | null;
       email?: string | null;
       occupation?: string | null;
+      role?: string | null;
     };
     expires: ISODateString;
   }


### PR DESCRIPTION
## Summary
- mark root path as public
- secure admin routes in middleware using role from the JWT
- include `role` in session types
- redirect authenticated admins away from the public page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a0d848f208327bf8a5db99319cad1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of authenticated users by redirecting them as needed on the book search page.
  * User roles are now included in session data, enabling more precise access control.

* **Bug Fixes**
  * Publicly accessible routes now include the user dashboard, allowing broader access without authentication.

* **Refactor**
  * Enhanced route protection by distinguishing between admin, public, and other routes, ensuring only authorized users can access admin pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->