### PR TITLE
Configure npm link script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies and run the development server:
 
 ```bash
+npm install
 npm run dev
 # or
 yarn dev
@@ -12,6 +13,24 @@ yarn dev
 pnpm dev
 # or
 bun dev
+```
+
+To link this package globally for development, run:
+
+```bash
+npm run link
+```
+
+Run the linter to check code style:
+
+```bash
+npm run lint
+```
+
+Run the unit tests:
+
+```bash
+npm test
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../src/app/page';
+
+describe('Home page', () => {
+  it('renders heading', () => {
+    render(<Home />);
+    expect(screen.getByText('Library Management System')).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "link": "npm link",
+    "postinstall": "prisma generate",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",
@@ -50,6 +52,10 @@
     "eslint-config-next": "14.2.4",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.6",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest config with a basic home page test
- document linting and testing instructions

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0ffb6c508327841e417e1f9c7010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README with clearer setup instructions, including steps for installing dependencies, linking the package, running the linter, and executing tests.

* **Tests**
  * Added a new test for the Home page to verify correct rendering.
  * Introduced Jest configuration and setup for improved testing capabilities.

* **Chores**
  * Added new npm scripts for linking and running tests.
  * Included additional development dependencies for testing and linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->