### PR TITLE
Add render tests for all pages

### DIFF
--- a/__tests__/admin.test.tsx
+++ b/__tests__/admin.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Dashboard from '../src/app/admin/page';
+
+describe('Admin dashboard page', () => {
+  it('renders warning heading', () => {
+    render(<Dashboard />);
+    expect(screen.getByText('Warning List !!')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_book_create.test.tsx
+++ b/__tests__/admin_book_create.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/book/create/page';
+
+describe('Book Create page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Book Create')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_book_list.test.tsx
+++ b/__tests__/admin_book_list.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/book/list/page';
+
+describe('Book List page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Book List')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_book_update.test.tsx
+++ b/__tests__/admin_book_update.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/book/update/page';
+
+describe('Book Update page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Book Update')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_borrow_create.test.tsx
+++ b/__tests__/admin_borrow_create.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/borrow/create/page';
+
+describe('Borrow Book page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Borrow Book')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_borrow_list.test.tsx
+++ b/__tests__/admin_borrow_list.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/borrow/list/page';
+
+describe('Borrow List page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Borrow List')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_category_create.test.tsx
+++ b/__tests__/admin_category_create.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/category/create/page';
+
+describe('Category Create page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Category Create')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_category_list.test.tsx
+++ b/__tests__/admin_category_list.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/category/list/page';
+
+describe('Category List page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Category List')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_category_update.test.tsx
+++ b/__tests__/admin_category_update.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/category/update/page';
+
+describe('Category Update page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Category Update')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_return_create.test.tsx
+++ b/__tests__/admin_return_create.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/return/create/page';
+
+describe('Return Book page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Return Book')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_return_list.test.tsx
+++ b/__tests__/admin_return_list.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/return/list/page';
+
+describe('Return List page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Return List')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_student_create.test.tsx
+++ b/__tests__/admin_student_create.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/student/create/page';
+
+describe('Student Register page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Student Register')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_student_list.test.tsx
+++ b/__tests__/admin_student_list.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/student/list/page';
+
+describe('Student List page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Student List')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_student_update.test.tsx
+++ b/__tests__/admin_student_update.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/student/update/page';
+
+describe('Student Update page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Student Update')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_teacher_create.test.tsx
+++ b/__tests__/admin_teacher_create.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/teacher/create/page';
+
+describe('Teacher Create page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Teacher Create')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_teacher_list.test.tsx
+++ b/__tests__/admin_teacher_list.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/teacher/list/page';
+
+describe('Teacher List page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Teacher List')).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin_teacher_update.test.tsx
+++ b/__tests__/admin_teacher_update.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Page from '../src/app/admin/teacher/update/page';
+
+describe('Teacher Update page', () => {
+  it('renders heading', () => {
+    render(<Page />);
+    expect(screen.getByText('Teacher Update')).toBeInTheDocument();
+  });
+});

--- a/__tests__/login.test.tsx
+++ b/__tests__/login.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Login from '../src/app/login/page';
+
+describe('Login page', () => {
+  it('renders heading', () => {
+    render(<Login />);
+    expect(screen.getByText('Sign in')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add simple tests for each page component to check headings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a163a002883278a839a685a78e7ba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify that headings are correctly rendered on various pages, including Admin Dashboard, Book Create/List/Update, Borrow Create/List, Category Create/List/Update, Return Create/List, Student Register/List/Update, Teacher Create/List/Update, and Login pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->